### PR TITLE
feat(equipment): added specific scale equipment and device type

### DIFF
--- a/src/schema/enum/device-type.json
+++ b/src/schema/enum/device-type.json
@@ -18,6 +18,7 @@
     "ACTUATOR",
     "CABLE",
     "ENCLOSURE",
-    "CIRCUIT_BREAKER"
+    "CIRCUIT_BREAKER",
+    "SCALE"
   ]
 }

--- a/src/schema/enum/equipment-type.json
+++ b/src/schema/enum/equipment-type.json
@@ -23,6 +23,7 @@
     "RUDDER",
     "PROPELLER",
     "PUMP",
-    "SENSOR"
+    "SENSOR",
+    "SCALE"
   ]
 }


### PR DESCRIPTION
In this pull request I have added a specific `SCALE` equipment and device type as `SENSOR` was to broad for a scale.